### PR TITLE
Cleanup and add additional gitignore directories and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
-vendor
-ansible/credentials
+# Misc
+/ansible/credentials
 .directory
+
+# MacOS
+.DS_Store
+
+# Composer
+composer.phar
+composer.lock
+/vendor/
+/wpcs/
+
+# Docker Related
 docker/spid-testenv2/users.json
 docker/spid-testenv2/config.yaml
 docker/spid-testenv2/idp.key


### PR DESCRIPTION
Note that `/vendor` is set to gitignore. A following pull request will move `spid-php-lib` outside of Composer.