### PR TITLE
Add WordPress Coding Standards for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,31 @@
         "email": "paolo.greppi@libpf.com"
     }],
     "require": {
-        "php": ">=7.0",
-        "italia/spid-php-lib": "^0.20.0"
+
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "*",
+        "wp-coding-standards/wpcs": "*",
+        "phpunit/phpunit": "6.*",
+        "wimg/php-compatibility": "^9.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+    },
+    "scripts": {
+        "test": [
+            "phpunit"
+        ],
+        "phpcs": [
+            "phpcs -s -p"
+        ],
+        "phpcbf": [
+            "phpcbf -p"
+        ]
+    },
+    "extra": {
+        "scripts-description": {
+            "test": "Run unit tests",
+            "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+            "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+        }
     }
 }


### PR DESCRIPTION
- `spid-php-lib` moved outside of Composer
- Include WordPress coding standards
- Include PHPUnit for future unit testing
- Include php-compatibility to test for PHP7+