### PR TITLE
fix error when I load http://spid-wordpress.simevo.com/wp-login.php

### DIFF
--- a/templates/spid-button.php
+++ b/templates/spid-button.php
@@ -12,7 +12,7 @@
 ?>
 <div id='spid-button' aria-live="polite">
 	<noscript>
-		<?php _esc_attr_e( 'To use the SPID Smart Button, please enable javascript.', 'spid-wordpress' ); ?>
+		<?php esc_attr_e( 'To use the SPID Smart Button, please enable javascript.', 'spid-wordpress' ); ?>
 	</noscript>
 </div>
 


### PR DESCRIPTION
I get this in `/var/log/apache2/error.log`:
```
[Fri Oct 26 15:57:21.812837 2018] [mpm_prefork:notice] [pid 12508] AH00163: Apache/2.4.25 (Debian) configured -- resuming normal operations
[Fri Oct 26 15:57:21.812964 2018] [core:notice] [pid 12508] AH00094: Command line: '/usr/sbin/apache2'
[Fri Oct 26 15:57:26.483441 2018] [:error] [pid 12510] [client 151.32.173.77:42264] PHP Fatal error:  Uncaught Error: Call to undefined function _esc_attr_e() in /var/www/html/wp-content/plugins/spid-wordpress/templates/spid-button.php:15\nStack trace:\n#0 /var/www/html/wp-content/plugins/spid-wordpress/includes/class-spid-core.php(86): include_once()\n#1 /var/www/html/wp-includes/class-wp-hook.php(286): SPID_Core->filterLoginMessage('')\n#2 /var/www/html/wp-includes/plugin.php(203): WP_Hook->apply_filters('', Array)\n#3 /var/www/html/wp-login.php(197): apply_filters('login_message', '')\n#4 /var/www/html/wp-login.php(1012): login_header('Login', '', Object(WP_Error))\n#5 {main}\n  thrown in /var/www/html/wp-content/plugins/spid-wordpress/templates/spid-button.php on line 15
```