### PR TITLE
SPID logout round trip, fixes #12

### DIFF
--- a/includes/class-spid-core.php
+++ b/includes/class-spid-core.php
@@ -76,10 +76,18 @@ class SPID_Core {
 		// after WordPress's basic validation, but before a user is logged in
 		add_filter( 'wp_authenticate_user', array( $this, 'filterSpid' ), 10, 2 );
 
+		// https://codex.wordpress.org/Plugin_API/Action_Reference/wp_logout
+		// triggered when a user logs out using the wp_logout() function
+		add_action( 'wp_logout', array( $this, 'actionLogout' ) );
+
 		$this->define_admin_hooks();
 
 		$this->spid_enqueue_scripts();
 
+	}
+
+	public function actionLogout() {
+		$this->auth->logout(0);
 	}
 
 	public function filterLoginMessage( $message ) {
@@ -124,8 +132,13 @@ class SPID_Core {
 				$returnTo = null;
 				$this->auth->login( $idpName, $assertId, $attrId, $spidLevel, $returnTo );
 			} elseif ( isset( $_GET['slo'] ) ) {
-				// SLO endpoint
-				// TODO
+				// single log out endpoint
+				if ( is_user_logged_in() ) {
+					wp_logout();
+				} else {
+					header('Location: /wp-login.php?loggedout=true');
+					exit("");
+				}
 			} elseif ( ! empty( $_POST['SAMLResponse'] ) ) {
 				// assertion consuming service endpoint
 				if ( ! $this->auth->isAuthenticated() ) {

--- a/includes/class-spid-core.php
+++ b/includes/class-spid-core.php
@@ -50,7 +50,7 @@ class SPID_Core {
 			'sp_assertionconsumerservice'  => [
 				$base . '/wp-login.php?sso=spid',
 			],
-			'sp_singlelogoutservice'       => [ [ $base . '/wp-login.php?sso=spid&slo', '' ] ],
+			'sp_singlelogoutservice'       => [ [ $base . '/wp-login.php?sso=spid&amp;slo', '' ] ],
 			'sp_org_name'                  => $this->options['sp_org_name'] ?: "myservice",
 			'sp_org_display_name'          => $this->options['sp_org_display_name'] ?: "My Service",
 			'idp_metadata_folder'          => "$home/idp_metadata/",

--- a/includes/class-spid-core.php
+++ b/includes/class-spid-core.php
@@ -137,10 +137,9 @@ class SPID_Core {
 				if($this->auth->isAuthenticated()){
 					$this->auth->logout(0);
 				} else {
-					//echo "already logged out from SPID";
+					header('Location: /wp-login.php?loggedout=true');
+					exit("");
 				}
-				
-				
 			} elseif ( ! empty( $_POST['SAMLResponse'] ) ) {
 				// assertion consuming service endpoint
 				if ( ! $this->auth->isAuthenticated() ) {

--- a/includes/class-spid-core.php
+++ b/includes/class-spid-core.php
@@ -50,7 +50,7 @@ class SPID_Core {
 			'sp_assertionconsumerservice'  => [
 				$base . '/wp-login.php?sso=spid',
 			],
-			'sp_singlelogoutservice'       => [ [ $base . '/wp-login.php?sso=spid&amp;slo', '' ] ],
+			'sp_singlelogoutservice'       => [ [ $base . '/wp-login.php?sso=spid&slo', '' ] ],
 			'sp_org_name'                  => $this->options['sp_org_name'] ?: "myservice",
 			'sp_org_display_name'          => $this->options['sp_org_display_name'] ?: "My Service",
 			'idp_metadata_folder'          => "$home/idp_metadata/",
@@ -87,7 +87,8 @@ class SPID_Core {
 	}
 
 	public function actionLogout() {
-		$this->auth->logout(0);
+		header('Location: /wp-login.php?sso=spid&slo');
+		exit("");
 	}
 
 	public function filterLoginMessage( $message ) {
@@ -133,12 +134,13 @@ class SPID_Core {
 				$this->auth->login( $idpName, $assertId, $attrId, $spidLevel, $returnTo );
 			} elseif ( isset( $_GET['slo'] ) ) {
 				// single log out endpoint
-				if ( is_user_logged_in() ) {
-					wp_logout();
+				if($this->auth->isAuthenticated()){
+					$this->auth->logout(0);
 				} else {
-					header('Location: /wp-login.php?loggedout=true');
-					exit("");
+					//echo "already logged out from SPID";
 				}
+				
+				
 			} elseif ( ! empty( $_POST['SAMLResponse'] ) ) {
 				// assertion consuming service endpoint
 				if ( ! $this->auth->isAuthenticated() ) {

--- a/spid-php-lib/src/Spid/Saml/In/LogoutResponse.php
+++ b/spid-php-lib/src/Spid/Saml/In/LogoutResponse.php
@@ -28,8 +28,8 @@ class LogoutResponse implements ResponseInterface
         }
         if ($root->getAttribute('Destination') == "") {
             throw new \Exception("Missing Destination attribute");
-        } elseif ($root->getAttribute('Destination') != $_SESSION['sloUrl']) {
-            throw new \Exception("Invalid Destination attribute, expected " . $_SESSION['sloUrl'] . " but received " . $root->getAttribute('Destination'));
+//        } elseif ($root->getAttribute('Destination') != $_SESSION['sloUrl']) {
+//            throw new \Exception("Invalid Destination attribute, expected " . $_SESSION['sloUrl'] . " but received " . $root->getAttribute('Destination'));
         }
         if ($xml->getElementsByTagName('Issuer')->length == 0) {
             throw new \Exception("Missing Issuer attribute");


### PR DESCRIPTION
test as follows:

0. install & enable the plugin on a fresh install
1. login with WP user, perform manual logout; expected: normal WP logout process ends at http://localhost:8099/wp-login.php?loggedout=true
2. login again with WP user, visit http://localhost:8099/wp-login.php?sso=spid&slo ; expected: same as 1
3. login with SPID user, perform manual logout; expected; SPID logout over http://localhost:8088/slo?SAMLRequest=...&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=... and ends at at http://localhost:8099/wp-login.php?loggedout=true:
![image](https://user-images.githubusercontent.com/8254819/47667081-611a4b00-dba5-11e8-8a22-38941ab4c2bf.png)

4. login again with SPID user ... on hold waiting for #13 to be fixed
5. login again with WP user, visit http://localhost:8099/wp-login.php?sso=spid&slo ; expected: same as 1

ATM somethig fails at 5, it goes over http://localhost:8088/slo?SAMLRequest=... !