### PR TITLE
save SPID attributes in wp_usermeta, fixes #31

### DIFF
--- a/includes/class-spid-core.php
+++ b/includes/class-spid-core.php
@@ -145,6 +145,11 @@ class SPID_Core {
 				}
 				$user = get_user_by( 'id', $user_id );
 
+				foreach ( $attributes as $key => $value ) {
+					if ( ! in_array( $key, ['spidCode', 'name', 'familyName', 'email'] ) ) {
+						add_user_meta ( $user_id, "spid_$key", $value, true );
+					}
+				}
 			} else {
 				return new WP_Error( 'spid_wrong_endpoint', 'Wrong endpoint' );
 			}


### PR DESCRIPTION
we do not save as user meta these attributes because we save them as user data:
- spidCode
- email
- name
- familyName